### PR TITLE
fix typo in addons.make of example

### DIFF
--- a/example/ofxLibFreenect2Example/addons.make
+++ b/example/ofxLibFreenect2Example/addons.make
@@ -1,2 +1,2 @@
-ofxLibfreenect2
+ofxLibFreenect2
 ofxOpenCv


### PR DESCRIPTION
Fix a small typo preventing the Build on Linux